### PR TITLE
✨ make parenthesis auto-closing/surrounding

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -10,10 +10,12 @@
     // Symbols that are auto closed when typing.
     "autoClosingPairs": [
         ["[", "]"],
-        ["%{", "%}"]
+        ["%{", "%}"],
+        ["(", ")"]
     ],
     // Symbols that that can be used to surround a selection.
     "surroundingPairs": [
-        ["%{", "%}"]
+        ["%{", "%}"],
+        ["(", ")"]
     ]
 }


### PR DESCRIPTION
Thanks to this commit, your parenthesis will autoclose and the text you selected can now be surrounded by parenthesis