### PR TITLE
✨ make curly braces auto-closing/surrounding

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -11,11 +11,13 @@
     "autoClosingPairs": [
         ["[", "]"],
         ["%{", "%}"],
-        ["(", ")"]
+        ["(", ")"],
+        ["{", "}"],
     ],
     // Symbols that that can be used to surround a selection.
     "surroundingPairs": [
         ["%{", "%}"],
-        ["(", ")"]
+        ["(", ")"],
+        ["{", "}"]
     ]
 }


### PR DESCRIPTION
Thanks to this commit, your curly braces will autoclose and the text you selected can now be surrounded by parenthesis